### PR TITLE
feat: Dockerコンテナ対応の設定変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
     build: .
+    ports:
+      - 7861:7861
     volumes:
       - .:/app
     working_dir: /app

--- a/src/main.py
+++ b/src/main.py
@@ -82,7 +82,7 @@ def main():
     print("Deep Novelist を起動中...", flush=True)
     interface = create_web_interface()
     interface.queue()  # ストリーム出力のためにキューを有効化
-    interface.launch(server_name="127.0.0.1", server_port=7861, share=True)
+    interface.launch(server_name="0.0.0.0", server_port=7861, share=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 変更内容

### 追加した機能
- Dockerコンテナ外部からのアクセスを可能にするポート設定の追加（7861:7861）

### 変更・修正した機能
- サーバーのホスト設定を「127.0.0.1」から「0.0.0.0」に変更し、コンテナ外部からのアクセスを許可

### 削除した機能
なし

## 変更理由
Dockerコンテナ内で実行されるアプリケーションに外部からアクセスできるようにするため。

## 影響範囲
- [x] 既存の機能への影響
  - コンテナ外部からのアクセスが可能になります
- [ ] パフォーマンスへの影響
  - 特になし
- [x] セキュリティへの影響
  - コンテナ外部からのアクセスを許可するため、適切なネットワーク設定が必要

## 動作確認
- [ ] ユニットテストの追加・更新
- [ ] 動作確認の実施
  - Dockerコンテナ起動後、外部からのアクセス確認
- [ ] ドキュメントの更新

## チェックリスト
- [x] コーディング規約に準拠している
- [x] 適切なコメントを追加している
- [ ] 必要なテストを追加している
- [ ] ドキュメントを更新している